### PR TITLE
Better Bot State System Bug Fix

### DIFF
--- a/lua/Action/TBotBaseAction.lua
+++ b/lua/Action/TBotBaseAction.lua
@@ -955,6 +955,8 @@ function UnRegisterTBotActionHook( oldHook )
 	
 end
 
+gameevent.Listen( "player_say" )
+
 -- Register some default events for the action system!
 -- NOTE: You can add the register hook function to your custom actions.
 RegisterTBotActionHook( "DoPlayerDeath" )
@@ -964,7 +966,7 @@ RegisterTBotActionHook( "PlayerSilentDeath" )
 RegisterTBotActionHook( "EntityEmitSound" )
 RegisterTBotActionHook( "EntityTakeDamage" )
 RegisterTBotActionHook( "PlayerHurt" )
-RegisterTBotActionHook( "PlayerSay" ) -- TODO: I should change this to player_say, since it will accept the modified returns from PlayerSay
+RegisterTBotActionHook( "player_say" ) -- NOTE: I changed this to player_say, since it will accept the modified returns from PlayerSay
 RegisterTBotActionHook( "PlayerSpawn" )
 RegisterTBotActionHook( "OnPlayerJump" )
 RegisterTBotActionHook( "OnPlayerHitGround" )

--- a/lua/Action/TBotBaseAction.lua
+++ b/lua/Action/TBotBaseAction.lua
@@ -964,7 +964,7 @@ RegisterTBotActionHook( "PlayerSilentDeath" )
 RegisterTBotActionHook( "EntityEmitSound" )
 RegisterTBotActionHook( "EntityTakeDamage" )
 RegisterTBotActionHook( "PlayerHurt" )
-RegisterTBotActionHook( "PlayerSay" )
+RegisterTBotActionHook( "PlayerSay" ) -- TODO: I should change this to player_say, since it will accept the modified returns from PlayerSay
 RegisterTBotActionHook( "PlayerSpawn" )
 RegisterTBotActionHook( "OnPlayerJump" )
 RegisterTBotActionHook( "OnPlayerHitGround" )
@@ -1013,9 +1013,10 @@ function TBotBaseActionMeta:ProcessHookEvent( method, ... )
 			end
 		
 		]]
+		-- FIXME: Certain operations create errors in these hooks when Lua is shuting down, there has to be a way to fix this!
 		-- HACKHACK: We check if the actor is vaild since when the server shuts down this creates errors.....
 		local hookFunc = _action[ method ] -- We can't do _action.method since it won't be dynamic. :(
-		if isfunction( hookFunc ) and IsValid( self.m_actor ) then
+		if isfunction( hookFunc ) and IsValid( self.m_actor ) and istable( self.m_actor:GetTable() ) then
 		
 			_result = hookFunc( _action, self.m_actor, ... ) or _result
 			
@@ -1052,6 +1053,7 @@ function TBotBaseActionMeta:StorePendingEventResult( result, eventName )
 		if self.m_eventResult.m_priority == TBotEventResultPriorityType.RESULT_CRITICAL then
 		
 			print( string.format( "%i: WARNING: %s::%s() RESULT_CRITICAL collision\n", CurTime(), self:GetName(), eventName or "" ) )
+			print( string.format( "%i: WARNING: %s::%s() RESULT_CRITICAL collided\n", CurTime(), self.m_eventResult.m_action and self.m_eventResult.m_action:GetName() or "NULL", eventName or "") )
 			
 		end
 		

--- a/lua/Action/TBotDead.lua
+++ b/lua/Action/TBotDead.lua
@@ -6,7 +6,19 @@ DEFINE_BASECLASS( "TBotBaseAction" )
 
 local TBotDeadMeta = {}
 
-TBotDeadMeta.__index = setmetatable( TBotDeadMeta, BaseClass )
+function TBotDeadMeta:__index( key ) 
+
+	-- Search the metatable.
+	local val = TBotDeadMeta[ key ] 
+	if val != nil then return val end
+	
+	-- Search the base class.
+	val = BaseClass[ key ]
+	if val != nil then return val end
+	
+	return nil
+	
+end
 
 function TBotDead()
 	local tbotdead = TBotBaseAction()

--- a/lua/Action/TBotMainAction.lua
+++ b/lua/Action/TBotMainAction.lua
@@ -335,24 +335,23 @@ function TBotMainActionMeta:PlayerSay( me, sender, text, teamChat )
 	if hook.Run( "PlayerCanSeePlayersChat", text, teamChat, me, sender ) then
 
 		local botTable = me:GetTable()
-		local startpos, endpos, botName = string.find( text, me:Nick() )
+		local botNamePattern = string.format( "^(%s) +(.*)$", me:Nick() )
 		local textTable
-		local command
+		local _, command = string.match( text, botNamePattern )
 
-		if isnumber( startpos ) and startpos == 1 then -- Only run the command if the bot name was said first!
+		if isstring( command ) then -- Only run the command if the bot name was said first!
 
-			textTable = string.Explode( " ", string.sub( text, endpos + 1 ) ) -- Grab everything else after the name!
-			table.remove( textTable, 1 ) -- Remove the unnecessary whitespace
-			command = textTable[ 1 ] and textTable[ 1 ]:lower()
+			textTable = string.Explode( " ", command ) -- Grab everything else after the name!
+			command = textTable[ 1 ] and textTable[ 1 ]:lower() -- Make it case insenstive
 
 		else
 
-			startpos, endpos, botName = string.find( text:lower(), "bots" )
-			if isnumber( startpos ) and startpos == 1 then -- Check to see if the player is commanding every bot!
+			local botsPattern = string.format( "^(%s) +(.*)$", "bots" )
+			_, command = string.match( text:lower(), botsPattern )
+			if isstring( command ) then -- Check to see if the player is commanding every bot!
 
-				textTable = string.Explode( " ", string.sub( text, endpos + 1 ) ) -- Grab everything else after the name!
-				table.remove( textTable, 1 ) -- Remove the unnecessary whitespace
-				command = textTable[ 1 ] and textTable[ 1 ]:lower()
+				textTable = string.Explode( " ", command ) -- Grab everything else after the name!
+				command = textTable[ 1 ] and textTable[ 1 ]:lower() -- Make it case insenstive
 
 			end
 

--- a/lua/Action/TBotMainAction.lua
+++ b/lua/Action/TBotMainAction.lua
@@ -327,9 +327,12 @@ function TBotMainActionMeta:PlayerDisconnected( me, ply )
 
 end
 
-function TBotMainActionMeta:PlayerSay( me, sender, text, teamChat )
+function TBotMainActionMeta:player_say( me, data )
+	local sender = Player( data.userid )
 	if !IsValid( sender ) then return self:TryContinue() end
 
+	local text = data.text
+	local teamChat = tobool( data.teamonly )
 	-- HACKHACK: PlayerCanSeePlayersChat is called after PlayerSay, so we call it to check if the bot can see the chat message.
 	-- NEEDTOVALIDATE: Would it be better if I used the PlayerCanSeePlayersChat hook instead?
 	if hook.Run( "PlayerCanSeePlayersChat", text, teamChat, me, sender ) then

--- a/lua/Action/TBotRetreatToCover.lua
+++ b/lua/Action/TBotRetreatToCover.lua
@@ -165,6 +165,13 @@ function TBotRetreatToCoverMeta:Update( me, interval )
 			
 		end
 		
+		-- Should the bot run when retreating to cover?
+		--[[if me:GetSuitPower() > 20 then
+		
+			me:PressRun()
+			
+		end]]
+		
 		self.m_path:Update( me )
 		
 	end

--- a/lua/Action/TBotScenarioMonitor.lua
+++ b/lua/Action/TBotScenarioMonitor.lua
@@ -215,9 +215,12 @@ function TBotScenarioMonitorMeta:FindReviveTarget( me )
 	
 end
 
-function TBotScenarioMonitorMeta:PlayerSay( me, sender, text, teamChat )
+function TBotScenarioMonitorMeta:player_say( me, data )
+	local sender = Player( data.userid )
 	if !IsValid( sender ) then return self:TryContinue() end
 
+	local text = data.text
+	local teamChat = tobool( data.teamonly )
 	-- HACKHACK: PlayerCanSeePlayersChat is called after PlayerSay, so we call it to check if the bot can see the chat message.
 	-- NEEDTOVALIDATE: Would it be better if I used the PlayerCanSeePlayersChat hook instead?
 	if hook.Run( "PlayerCanSeePlayersChat", text, teamChat, me, sender ) then

--- a/lua/Action/TBotScenarioMonitor.lua
+++ b/lua/Action/TBotScenarioMonitor.lua
@@ -223,24 +223,23 @@ function TBotScenarioMonitorMeta:PlayerSay( me, sender, text, teamChat )
 	if hook.Run( "PlayerCanSeePlayersChat", text, teamChat, me, sender ) then
 
 		local botTable = me:GetTable()
-		local startpos, endpos, botName = string.find( text, me:Nick() )
+		local botNamePattern = string.format( "^(%s) +(.*)$", me:Nick() )
 		local textTable
-		local command
+		local _, command = string.match( text, botNamePattern )
 
-		if isnumber( startpos ) and startpos == 1 then -- Only run the command if the bot name was said first!
+		if isstring( command ) then -- Only run the command if the bot name was said first!
 
-			textTable = string.Explode( " ", string.sub( text, endpos + 1 ) ) -- Grab everything else after the name!
-			table.remove( textTable, 1 ) -- Remove the unnecessary whitespace
-			command = textTable[ 1 ] and textTable[ 1 ]:lower()
+			textTable = string.Explode( " ", command ) -- Grab everything else after the name!
+			command = textTable[ 1 ] and textTable[ 1 ]:lower() -- Make it case insenstive
 
 		else
 
-			startpos, endpos, botName = string.find( text:lower(), "bots" )
-			if isnumber( startpos ) and startpos == 1 then -- Check to see if the player is commanding every bot!
+			local botsPattern = string.format( "^(%s) +(.*)$", "bots" )
+			_, command = string.match( text:lower(), botsPattern )
+			if isstring( command ) then -- Check to see if the player is commanding every bot!
 
-				textTable = string.Explode( " ", string.sub( text, endpos + 1 ) ) -- Grab everything else after the name!
-				table.remove( textTable, 1 ) -- Remove the unnecessary whitespace
-				command = textTable[ 1 ] and textTable[ 1 ]:lower()
+				textTable = string.Explode( " ", command ) -- Grab everything else after the name!
+				command = textTable[ 1 ] and textTable[ 1 ]:lower() -- Make it case insenstive
 
 			end
 

--- a/lua/Action/TBotSearchAndDestory.lua
+++ b/lua/Action/TBotSearchAndDestory.lua
@@ -96,7 +96,7 @@ end
 
 function TBotSearchAndDestoryMeta:RecomputeSeekPath( me )
 
-	local goalVector = navmesh.Find( me:GetPos(), math.huge, me:GetMaxJumpHeight(), 1000 )
+	local goalVector = navmesh.Find( me:GetPos(), math.huge, me:GetTBotLocomotion():GetMaxJumpHeight(), 1000 )
 	
 	if #goalVector == 0 then
 	

--- a/lua/Action/TBotUseEntity.lua
+++ b/lua/Action/TBotUseEntity.lua
@@ -114,24 +114,23 @@ function TBotUseEntityMeta:PlayerSay( me, sender, text, teamChat )
 	if hook.Run( "PlayerCanSeePlayersChat", text, teamChat, me, sender ) then
 
 		local botTable = me:GetTable()
-		local startpos, endpos, botName = string.find( text, me:Nick() )
+		local botNamePattern = string.format( "^(%s) +(.*)$", me:Nick() )
 		local textTable
-		local command
+		local _, command = string.match( text, botNamePattern )
 
-		if isnumber( startpos ) and startpos == 1 then -- Only run the command if the bot name was said first!
+		if isstring( command ) then -- Only run the command if the bot name was said first!
 
-			textTable = string.Explode( " ", string.sub( text, endpos + 1 ) ) -- Grab everything else after the name!
-			table.remove( textTable, 1 ) -- Remove the unnecessary whitespace
-			command = textTable[ 1 ] and textTable[ 1 ]:lower()
+			textTable = string.Explode( " ", command ) -- Grab everything else after the name!
+			command = textTable[ 1 ] and textTable[ 1 ]:lower() -- Make it case insenstive
 
 		else
 
-			startpos, endpos, botName = string.find( text:lower(), "bots" )
-			if isnumber( startpos ) and startpos == 1 then -- Check to see if the player is commanding every bot!
+			local botsPattern = string.format( "^(%s) +(.*)$", "bots" )
+			_, command = string.match( text:lower(), botsPattern )
+			if isstring( command ) then -- Check to see if the player is commanding every bot!
 
-				textTable = string.Explode( " ", string.sub( text, endpos + 1 ) ) -- Grab everything else after the name!
-				table.remove( textTable, 1 ) -- Remove the unnecessary whitespace
-				command = textTable[ 1 ] and textTable[ 1 ]:lower()
+				textTable = string.Explode( " ", command ) -- Grab everything else after the name!
+				command = textTable[ 1 ] and textTable[ 1 ]:lower() -- Make it case insenstive
 
 			end
 

--- a/lua/Action/TBotUseEntity.lua
+++ b/lua/Action/TBotUseEntity.lua
@@ -106,9 +106,12 @@ function TBotUseEntityMeta:Update( me, interval )
 
 end
 
-function TBotUseEntityMeta:PlayerSay( me, sender, text, teamChat )
+function TBotUseEntityMeta:player_say( me, data )
+	local sender = Player( data.userid )
 	if !IsValid( sender ) then return self:TryContinue() end
 
+	local text = data.text
+	local teamChat = tobool( data.teamonly )
 	-- HACKHACK: PlayerCanSeePlayersChat is called after PlayerSay, so we call it to check if the bot can see the chat message.
 	-- NEEDTOVALIDATE: Would it be better if I used the PlayerCanSeePlayersChat hook instead?
 	if hook.Run( "PlayerCanSeePlayersChat", text, teamChat, me, sender ) then

--- a/lua/Path/TBotPath.lua
+++ b/lua/Path/TBotPath.lua
@@ -735,6 +735,10 @@ end
 
 local function TRizzleBotRangeCheck( area, fromArea, ladder, portal, bot, length )
 	
+	local isBotValid = IsValid( bot )
+	local isLadderValid = IsValid( ladder )
+	local isPortalValid = IsValid( portal )
+	
 	if !IsValid( fromArea ) then
 	
 		-- first area in path, no cost
@@ -766,21 +770,19 @@ local function TRizzleBotRangeCheck( area, fromArea, ladder, portal, bot, length
 		end
 		
 		-- If the portal is disabled then we can't use it!
-		if IsValid( portal ) and portal:GetInternalVariable( "m_bDisabled" ) then
+		if isPortalValid and portal:GetInternalVariable( "m_bDisabled" ) then
 		
 			return -1.0
 			
 		end
 		
 		local Height	=	fromArea:ComputeAdjacentConnectionHeightChange( area )
-		local stepHeight = 18
-		if IsValid( bot ) then stepHeight = bot:GetStepSize() end
+		local stepHeight = isBotValid and bot:GetStepSize() or 18
 		
 		-- Jumping is slower than ground movement.
-		if !IsValid( ladder ) and !IsValid( portal ) and !fromArea:IsUnderwater() and Height > stepHeight then
+		if !isLadderValid and !isPortalValid and !fromArea:IsUnderwater() and Height > stepHeight then
 			
-			local maximumJumpHeight = 64
-			if IsValid( bot ) then maximumJumpHeight = bot:GetTBotLocomotion():GetMaxJumpHeight() end
+			local maximumJumpHeight = isBotValid and bot:GetTBotLocomotion():GetMaxJumpHeight() or 64
 			
 			if Height > maximumJumpHeight then
 			
@@ -796,13 +798,13 @@ local function TRizzleBotRangeCheck( area, fromArea, ladder, portal, bot, length
 			
 			local fallDistance = -fromArea:ComputeGroundHeightChange( area )
 			
-			if IsValid( ladder ) and ladder:GetBottom().z < fromArea:GetCenter().z and ladder:GetBottom().z > area:GetCenter().z then
+			if isLadderValid and ladder:GetBottom().z < fromArea:GetCenter().z and ladder:GetBottom().z > area:GetCenter().z then
 			
 				fallDistance = ladder:GetBottom().z - area:GetCenter().z
 				
 			end
 			
-			if IsValid( portal ) and portal:GetPos().z < fromArea:GetCenter().z and portal:GetPos().z > area:GetCenter().z then
+			if isPortalValid and portal:GetPos().z < fromArea:GetCenter().z and portal:GetPos().z > area:GetCenter().z then
 			
 				fallDistance = portal:GetPos().z - area:GetCenter().z
 				
@@ -811,7 +813,7 @@ local function TRizzleBotRangeCheck( area, fromArea, ladder, portal, bot, length
 			--print( "Drop Height: " .. Height )
 			local fallDamage = GetApproximateFallDamage( fallDistance )
 			
-			if fallDamage > 0.0 and IsValid( bot ) then
+			if fallDamage > 0.0 and isBotValid then
 			
 				-- if the fall would kill us, don't use it
 				local deathFallMargin = 10.0

--- a/lua/Path/TBotPathFollower.lua
+++ b/lua/Path/TBotPathFollower.lua
@@ -754,6 +754,7 @@ function TBotPathFollowerMeta:Avoid( bot, goalPos, forward, left )
 		
 	end
 	
+	local botCollision = bot:GetCollisionGroup()
 	local body = bot:GetTBotBody()
 	local size = body:GetHullWidth() / 4
 	local offset = size + 2
@@ -798,7 +799,7 @@ function TBotPathFollowerMeta:Avoid( bot, goalPos, forward, left )
 	local leftAvoid = 0.0
 	
 	local result = {}
-	util.TraceHull( { start = leftFrom, endpos = leftTo, maxs = hullMax, mins = hullMin, filter = avoidFilter, mask = MASK_PLAYERSOLID, output = result } )
+	util.TraceHull( { start = leftFrom, endpos = leftTo, maxs = hullMax, mins = hullMin, filter = avoidFilter, mask = MASK_PLAYERSOLID, collisiongroup = botCollision, output = result } )
 	if result.Fraction < 1.0 or result.StartSolid then
 	
 		if result.StartSolid then
@@ -823,7 +824,7 @@ function TBotPathFollowerMeta:Avoid( bot, goalPos, forward, left )
 	local isRightClear = true
 	local rightAvoid = 0.0
 	
-	util.TraceHull( { start = rightFrom, endpos = rightTo, maxs = hullMax, mins = hullMin, filter = avoidFilter, mask = MASK_PLAYERSOLID, output = result } )
+	util.TraceHull( { start = rightFrom, endpos = rightTo, maxs = hullMax, mins = hullMin, filter = avoidFilter, mask = MASK_PLAYERSOLID, collisiongroup = botCollision, output = result } )
 	if result.Fraction < 1.0 or result.StartSolid then
 	
 		if result.StartSolid then

--- a/lua/Path/TBotRetreatPath.lua
+++ b/lua/Path/TBotRetreatPath.lua
@@ -57,7 +57,7 @@ function TBotRetreatPathMeta:Invalidate()
 end
 
 -- Make the bot move.
-function TBotRetreatPathMeta:Update( bot, threat )
+function TBotRetreatPathMeta:Update( bot, threat, cost )
 	
 	if !IsValid( threat ) then
 	
@@ -73,14 +73,14 @@ function TBotRetreatPathMeta:Update( bot, threat )
 	end
 	
 	-- Maintain path away from the threat
-	self:RefreshPath( bot, threat )
+	self:RefreshPath( bot, threat, cost )
 	
 	-- Move along the path towards the threat
 	BaseClass.Update( self, bot )
 	
 end
 
-function TBotRetreatPathMeta:RefreshPath( bot, threat )
+function TBotRetreatPathMeta:RefreshPath( bot, threat, cost )
 
 	local botTable = bot:GetTable()
 	local mover = bot:GetTBotLocomotion()
@@ -116,8 +116,9 @@ function TBotRetreatPathMeta:RefreshPath( bot, threat )
 		-- Remember our path threat
 		self.m_pathThreat = threat
 		self.m_pathThreatPos = threat:GetPos()
+		self:Invalidate() -- Clear the old path!
 		
-		local retreat = RetreatPathBuilder( bot, threat, self:GetMaxPathLength() )
+		local retreat = RetreatPathBuilder( bot, threat, self:GetMaxPathLength(), cost )
 		
 		local goalArea = retreat:ComputePath()
 		
@@ -595,7 +596,7 @@ function RetreatPathBuilderMeta:ComputePath()
 				end
 				
 				-- keep track of area farthest from threat
-				local threatRange = newArea:GetCenter():Distance( threat:GetPos() )
+				local threatRange = newArea:GetCenter():Distance( self.m_threat:GetPos() )
 				if threatRange > farthestRange then
 				
 					farthestArea = newArea

--- a/lua/autorun/client/TRizzleBot_Client.lua
+++ b/lua/autorun/client/TRizzleBot_Client.lua
@@ -276,7 +276,7 @@ function TRizzleBotCreateMenu( ply, cmd, args )
 			net.WriteString( PlayerModel:GetOptionText( PlayerModel.selected ) or "kleiner" )
 			net.WriteBool( SpawnWithPreferredWeapons:GetChecked() )
 		net.SendToServer()
-		Frame:Close()
+		--Frame:Close() -- Disabled since its annoying to have to reopen the menu every single time!
 	end
 
 end
@@ -451,7 +451,7 @@ function TRizzleBotRegisterWeaponMenu( ply, cmd, args )
 			net.WriteInt( MaxStoredAmmo:GetValue(), 32 )
 			net.WriteBool( IgnoreAutomaticRange:GetChecked() )
 		net.SendToServer()
-		Frame:Close()
+		--Frame:Close() -- Disabled since its annoying to have to reopen the menu every single time!
 	end
 
 end


### PR DESCRIPTION
As of the new state system update, I have taken the time to fix some of the bugs and regressions created by said update. I have also made a few optimizations to the code especially to the vision interface.

Change Log:
- Fixed #66 where the game would create errors if when leaving the server due to invalid table indexing
- Fixed #67 where bots with similar names, "Alyx and Alyx Vance," would follow commands issued rather than the bot that was addressed
- Attempted to fix #48, based on testing this works, but further testing is needed
- Added some comments about potential changes to the code, feedback would be appreciated
- Added some more debug comments and print statements
- Fixed TBotDeathMeta not using the same indexing method as the rest of the action system
- Fixed TBotSearchAndDestory using depreciated functions
- Fixed a long-time bug that existed since the beginning of this addon where the bot would violently spin around while in vehicles
- Fixed TBotVision::IsLookingAtPosition attempting to access a function that only existed on the ENTITY meta table
- Optimized TBotVision::IsAbleToSee by moving the fog checking code into the vision interface
- Fixed TBotVision::Blind attempted to index a variable that may or may not be initialized
- Optimized TRizzleBotRangeCheck by running all IsValid checks at the start of the function rather than during its execution
- Fixed TBotPathFollower::Avoid using a depreciated function
- Made some changes to TBotPathFollower::Avoid regarding how it manages colliding with other players
- TBotRetreatPath now accepts a cost function for pathfinding
- Fixed RetreatPathBuilder::ComputePath attempting to index and invalid variable
- Changed the client side vgui to not automatically close after creating a bot or registering a weapon
- Fixed PLAYER::TBotResetAI not resetting the rest of the bot's interfaces
- Made the code create more copies of vectors where needed rather than taking the risk of accidently editing the original vector
- Optimized PLAYER::UpdateLookingAroundForEnemies by reducing index calls
- Fixed PLAYER::IsLineOfFireClear not marking the line of fire as clear if the trace check hit its intended target
- Fixed PLAYER::BendLineOfSight calculating both sides twice. This is also an optimization since it now only does each side once
- Added more validity checks to the code
- Changed ENTITY::GetLastKnownArea to no longer check visibility for the closest CNavArea since it had some race cases where a CNavArea would be nearby, but would be obscured by an entity
- Fixed TRizzleBotInitialized hook being called to early causing some addons being unable to override code or register weapons, "the hook will now run the next frame after server start"
- Changed the bots to listen to the player_say hook since PlayerSay is normally used for chat commands and accepts modified returns from the PlayerSay hook